### PR TITLE
Add summary and description to gemspec

### DIFF
--- a/kondukter.gemspec
+++ b/kondukter.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Darko Fabijan"]
   spec.email         = ["darko@renderedtext.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{Kondukter provides info about running Passenger instance.}
+  spec.description   = %q{Kondukter provides info about running Passenger instance.}
+  spec.homepage      = "https://github.com/renderedtext/kondukter"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
On my machine, with Bundler 1.10.5, installation of all gems fails because summary is missing in Kondukter.

Please review.
